### PR TITLE
Fix :current_version not set problem

### DIFF
--- a/lib/capistrano/tasks/gitcopy.rake
+++ b/lib/capistrano/tasks/gitcopy.rake
@@ -13,6 +13,7 @@ namespace :gitcopy do
 
     if $?.exitstatus == 0
       system "git archive #{no_repo_url ? '' : "--remote #{fetch(:repo_url)}" } --format=tar #{fetch(:branch)}:#{fetch(:sub_directory)} | gzip > #{ archive_name }"
+      set :current_revision, `git rev-list --max-count=1 --abbrev-commit #{fetch(:branch)}`.chomp('')
     else
       puts "Can't find commit for: #{fetch(:branch)}"
     end


### PR DESCRIPTION
Usually, the deploy task will make the information for releasing revision, and write to `revision.log` and `release_path/REVISION`.

```
Branch master (at ebb8860) deployed as release 20150401125702 by hiroaki
```

But via `gitcopy`, it lack the revision:

```
Branch master (at ) deployed as release 20150401134017 by hiroaki
```

This commit a workaround but it works for me.
I consulted around here about `:current_revision`
https://github.com/capistrano/capistrano/blob/master/lib/capistrano/tasks/deploy.rake#L209
