### PR TITLE
This implementation is based on the internal Capistrano::Git strategy.

### DIFF
--- a/capistrano-scm-gitcopy.gemspec
+++ b/capistrano-scm-gitcopy.gemspec
@@ -1,21 +1,24 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
-  s.name        = "capistrano-scm-gitcopy"
-  s.version     = "0.0.10"
-  s.licenses    = ["MIT"]
-  s.authors     = ["Jack Wu", "Carl Douglas"]
-  s.email       = ["xuwupeng2000@gmail.com"]
-  s.homepage    = "https://github.com/xuwupeng2000/capsitrano-scm-gitcopy.git"
+  s.name        = 'capistrano-scm-gitcopy'
+  s.version     = '0.0.10'
+  s.licenses    = ['MIT']
+  s.authors     = ['Jack Wu', 'Carl Douglas']
+  s.email       = ['xuwupeng2000@gmail.com']
+  s.homepage    = 'https://github.com/xuwupeng2000/capsitrano-scm-gitcopy.git'
   s.summary     = %q{Gitcopy strategy for capistrano 3.x}
   s.description = %q{Gitcopy strategy for capistrano 3.x}
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  s.files         = `git ls-files`.split('\n')
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split('\n')
+  s.executables   = `git ls-files -- bin/*`.split('\n').map{ |f| File.basename(f) }
+  s.require_paths = ['lib']
 
   # specify any dependencies here; for example:
-  s.add_dependency "capistrano", "~> 3.0"
+  s.add_dependency 'capistrano', '~> 3.0'
+
+  s.add_development_dependency 'rspec', '~> 3.0.0'
+  s.add_development_dependency 'mocha'
 end

--- a/lib/capistrano/gitcopy.rb
+++ b/lib/capistrano/gitcopy.rb
@@ -1,1 +1,66 @@
 load File.expand_path('../tasks/gitcopy.rake', __FILE__)
+
+require 'capistrano/scm'
+
+set_if_empty :repo_path, -> { "/tmp/#{fetch(:application)}-repository" }
+
+class Capistrano::GitCopy < Capistrano::SCM
+
+  # execute git with argument in the context
+  #
+  def git(*args)
+    args.unshift :git
+    context.execute(*args)
+  end
+
+  module DefaultStrategy
+
+    def test
+      test! " [ -f #{repo_path}/HEAD ] "
+    end
+
+    def check
+      git :'ls-remote --heads', repo_url
+    end
+
+    def clone
+      if (depth = fetch(:git_shallow_clone))
+        git :clone, '--verbose', '--mirror', '--depth', depth, '--no-single-branch', repo_url, repo_path
+      else
+        git :clone, '--verbose', '--mirror', repo_url, repo_path
+      end
+    end
+
+    def update
+      # Note: Requires git version 1.9 or greater
+      if (depth = fetch(:git_shallow_clone))
+        git :fetch, '--depth', depth, 'origin', fetch(:branch)
+      else
+        git :remote, :update
+      end
+    end
+
+    def fetch_revision
+      context.capture(:git, "rev-list --max-count=1 --abbrev-commit --abbrev=12 #{fetch(:branch)}")
+    end
+
+    def local_tarfile
+      "#{fetch(:tmp_dir)}/#{fetch(:application)}-#{fetch(:current_revision).strip}.tar.gz"
+    end
+
+    def remote_tarfile
+      "#{fetch(:tmp_dir)}/#{fetch(:application)}-#{fetch(:current_revision).strip}.tar.gz"
+    end
+
+    def release
+      if (tree = fetch(:repo_tree))
+        tree = tree.slice %r#^/?(.*?)/?$#, 1
+        components = tree.split('/').size
+        git :archive, fetch(:branch), tree, '--format', 'tar', "|gzip > #{local_tarfile}"
+      else
+        git :archive, fetch(:branch), '--format', 'tar', "|gzip > #{local_tarfile}"
+      end
+    end
+  end 
+
+end

--- a/spec/lib/capistrano/gitcopy_spec.rb
+++ b/spec/lib/capistrano/gitcopy_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+require 'capistrano/gitcopy'
+
+module Capistrano
+  describe GitCopy do
+    let(:context) { Class.new.new }
+    subject { Capistrano::GitCopy.new(context, Capistrano::GitCopy::DefaultStrategy) }
+
+    describe "#git" do
+      it "should call execute git in the context, with arguments" do
+        context.expects(:execute).with(:git, :init)
+        subject.git(:init)
+      end
+    end
+  end
+
+  describe GitCopy::DefaultStrategy do
+    let(:context) { Class.new.new }
+    subject { Capistrano::GitCopy.new(context, Capistrano::GitCopy::DefaultStrategy) }
+
+    describe "#test" do
+      it "should call test for repo HEAD" do
+        context.expects(:repo_path).returns("/path/to/repo")
+        context.expects(:test).with " [ -f /path/to/repo/HEAD ] "
+
+        subject.test
+      end
+    end
+
+    describe "#check" do
+      it "should test the repo url" do
+        context.expects(:repo_url).returns(:url)
+        context.expects(:execute).with(:git, :'ls-remote --heads', :url).returns(true)
+
+        subject.check
+      end
+    end
+
+    describe "#clone" do
+      it "should run git clone" do
+        context.expects(:fetch).with(:git_shallow_clone).returns(nil)
+        context.expects(:repo_url).returns(:url)
+        context.expects(:repo_path).returns(:path)
+        context.expects(:execute).with(:git, :clone, '--mirror', :url, :path)
+
+        subject.clone
+      end
+
+      it "should run git clone in shallow mode" do
+        context.expects(:fetch).with(:git_shallow_clone).returns('1')
+        context.expects(:repo_url).returns(:url)
+        context.expects(:repo_path).returns(:path)
+
+        context.expects(:execute).with(:git, :clone, '--mirror', "--depth", '1', '--no-single-branch', :url, :path)
+
+        subject.clone
+      end
+    end
+
+    describe "#update" do
+      it "should run git update" do
+        context.expects(:fetch).with(:git_shallow_clone).returns(nil)
+        context.expects(:execute).with(:git, :remote, :update)
+
+        subject.update
+      end
+
+      it "should run git update in shallow mode" do
+        context.expects(:fetch).with(:git_shallow_clone).returns('1')
+        context.expects(:fetch).with(:branch).returns(:branch)
+        context.expects(:execute).with(:git, :fetch, "--depth", '1', "origin",  :branch)
+
+        subject.update
+      end
+    end
+
+    describe "#release" do
+      it "should run git archive without a subtree" do
+        context.expects(:fetch).with(:repo_tree).returns(nil)
+        context.expects(:fetch).with(:branch).returns(:branch)
+        context.expects(:release_path).returns(:path)
+
+        context.expects(:execute).with(:git, :archive, :branch, '| tar -x -f - -C', :path)
+
+        subject.release
+      end
+
+      it "should run git archive with a subtree" do
+        context.expects(:fetch).with(:repo_tree).returns('tree')
+        context.expects(:fetch).with(:branch).returns(:branch)
+        context.expects(:release_path).returns(:path)
+
+        context.expects(:execute).with(:git, :archive, :branch, 'tree', '| tar -x --strip-components 1 -f - -C', :path)
+
+        subject.release
+      end
+    end
+
+    describe "#fetch_revision" do
+      it "should capture git rev-list" do
+        context.expects(:fetch).with(:branch).returns(:branch)
+        context.expects(:capture).with(:git, "rev-list --max-count=1 --abbrev-commit --abbrev=12 branch").returns("01abcde")
+        revision = subject.fetch_revision
+        expect(revision).to eq("01abcde")
+      end
+    end
+  end
+end

--- a/spec/lib/capistrano/gitcopy_spec.rb
+++ b/spec/lib/capistrano/gitcopy_spec.rb
@@ -42,7 +42,7 @@ module Capistrano
         context.expects(:fetch).with(:git_shallow_clone).returns(nil)
         context.expects(:repo_url).returns(:url)
         context.expects(:repo_path).returns(:path)
-        context.expects(:execute).with(:git, :clone, '--mirror', :url, :path)
+        context.expects(:execute).with(:git, :clone, '--verbose', '--mirror', :url, :path)
 
         subject.clone
       end
@@ -52,7 +52,7 @@ module Capistrano
         context.expects(:repo_url).returns(:url)
         context.expects(:repo_path).returns(:path)
 
-        context.expects(:execute).with(:git, :clone, '--mirror', "--depth", '1', '--no-single-branch', :url, :path)
+        context.expects(:execute).with(:git, :clone, '--verbose', '--mirror', "--depth", '1', '--no-single-branch', :url, :path)
 
         subject.clone
       end
@@ -81,7 +81,9 @@ module Capistrano
         context.expects(:fetch).with(:branch).returns(:branch)
         context.expects(:release_path).returns(:path)
 
-        context.expects(:execute).with(:git, :archive, :branch, '| tar -x -f - -C', :path)
+        context.expects(:local_tarfile).returns('/tmp/rspec-test-ABCDEF.tar.gz')
+
+        context.expects(:execute).with(:git, :archive, :branch, "|gzip > /tmp/rspec-test-ABCDEF.tar.gz")
 
         subject.release
       end
@@ -91,7 +93,9 @@ module Capistrano
         context.expects(:fetch).with(:branch).returns(:branch)
         context.expects(:release_path).returns(:path)
 
-        context.expects(:execute).with(:git, :archive, :branch, 'tree', '| tar -x --strip-components 1 -f - -C', :path)
+        context.expects(:local_tarfile).returns('/tmp/rspec-test-ABCDEF.tar.gz')
+
+        context.expects(:execute).with(:git, :archive, :branch, 'tree', "|gzip > /tmp/rspec-test-ABCDEF.tar.gz")
 
         subject.release
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,16 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+$LOAD_PATH.unshift(File.dirname(__FILE__))
+require 'capistrano/all'
+require 'rspec'
+require 'mocha/api'
+require 'time'
+
+# Requires supporting files with custom matchers and macros, etc,
+# in ./support/ and its subdirectories.
+Dir['#{File.dirname(__FILE__)}/support/**/*.rb'].each {|f| require f}
+
+RSpec.configure do |config|
+	config.raise_errors_for_deprecations!
+  config.mock_framework = :mocha
+  config.order = 'random'
+end


### PR DESCRIPTION
It clones the repository locally before archiving to a tarfile
and then uploading it to the remote host servers.