### PR TITLE
Add the custom remote path possibility

### DIFF
--- a/lib/capistrano/gitcopy.rb
+++ b/lib/capistrano/gitcopy.rb
@@ -49,7 +49,11 @@ class Capistrano::GitCopy < Capistrano::SCM
     end
 
     def remote_tarfile
+      if (remote_tmp_dir = fetch(:remote_tmp_dir))
+      "#{fetch(:remote_tmp_dir)}/#{fetch(:application)}-#{fetch(:current_revision).strip}.tar.gz"
+      else
       "#{fetch(:tmp_dir)}/#{fetch(:application)}-#{fetch(:current_revision).strip}.tar.gz"
+      end
     end
 
     def release


### PR DESCRIPTION
Possibility to add a custom tmp path on the remote server, in case of the remote architecture is not the same as the deployment server.
Example : OVH hostings are homez.xxx/username/tmp